### PR TITLE
public iota_stronghold crate 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use crypto::keys::slip10::Chain;
-use iota_stronghold::{
+pub use iota_stronghold::{
     Location, ProcResult, Procedure, RecordHint, SLIP10DeriveInput, StrongholdFlags, VaultFlags,
 };
 use once_cell::sync::Lazy;


### PR DESCRIPTION
When using plugin from tauri, no need to install iota_stronghold crate, we can access it into plugin api